### PR TITLE
Add confirmation dialog for session close

### DIFF
--- a/src/renderer/components/view/pages/settings.vue
+++ b/src/renderer/components/view/pages/settings.vue
@@ -158,7 +158,10 @@ export default {
         },
 
         closeSession() {
-            this.removeSession({ sessionIndex: this.currentSessionIndex });
+            const confirmed = confirm('Are you sure you want to close this session?');
+            if (confirmed) {
+                this.removeSession({ sessionIndex: this.currentSessionIndex });
+            }
         },
 
         urlify(url) {


### PR DESCRIPTION
## Summary
• Added confirmation dialog when closing sessions to prevent accidental closures
• Users now see "Are you sure you want to close this session?" prompt before session is closed
• Improves user experience by preventing data loss from accidental clicks

## Test plan
- [ ] Navigate to session settings page
- [ ] Click "Close session" button
- [ ] Verify confirmation dialog appears
- [ ] Test both "OK" and "Cancel" options work correctly